### PR TITLE
updated to fix issue with documentIds in Android

### DIFF
--- a/android/src/main/java/cbl/js/kotiln/CollectionManager.kt
+++ b/android/src/main/java/cbl/js/kotiln/CollectionManager.kt
@@ -48,7 +48,11 @@ object CollectionManager {
         val col = this.getCollection(collectionName, scopeName, databaseName)
         col?.let { collection ->
             concurrencyControl?.let {
-                val mutableDocument = MutableDocument(documentId, document)
+                val mutableDocument = if (documentId.isEmpty()) {
+                    MutableDocument(document)
+                } else {
+                    MutableDocument(documentId, document)
+                }
                 val result = collection.save(mutableDocument, it)
                 if (result) {
                     return Pair(mutableDocument.id, true)


### PR DESCRIPTION
This fixes the issue that was put in with Android where if you send a mutable document without a documentId set (blank) it won't auto assign one.