### PR TITLE
updated for fixes to blobs for Android and fix react warnings about d…

### DIFF
--- a/android/src/main/java/com/couchbase/ionic/CblIonicPluginPlugin.kt
+++ b/android/src/main/java/com/couchbase/ionic/CblIonicPluginPlugin.kt
@@ -874,7 +874,7 @@ class CblIonicPluginPlugin : Plugin() {
                         if (blobData == null) {
                             results.put("data", emptyArray<Byte>())
                         } else {
-                            results.put("data", blobData)
+                            results.put("data", JSONArray(blobData))
                         }
                         call.resolve(results)
                     }

--- a/android/src/main/java/com/couchbase/ionic/PluginHelper.kt
+++ b/android/src/main/java/com/couchbase/ionic/PluginHelper.kt
@@ -191,16 +191,18 @@ object PluginHelper {
 
     fun documentToMap(document: Document): JSObject? {
         try {
-            val docJson = JSONObject(document.toMap())
+            val dMap = document.toMap()
+            val docJson = JSONObject(dMap)
             val keys: Iterator<*> = docJson.keys()
             while (keys.hasNext()) {
                 val key = keys.next() as String
-                val value = docJson[key]
+                val value = dMap[key]
+                //only replace the value if it's a blob because
+                //JSONObject will not map in the blob object into the JSON object
+                //since it's not a supported JSON type
                 if (value is Blob) {
                     val blobProps = JSONObject(value.getProperties())
                     docJson.put(key, blobProps)
-                } else {
-                    docJson.put(key, value)
                 }
             }
             val docMap = JSObject()
@@ -209,7 +211,7 @@ object PluginHelper {
             docMap.put("_sequence", document.sequence)
             return docMap
         } catch (ex: Exception) {
-            return null
+            throw ex
         }
     }
 

--- a/example/src/pages/databases/DatabaseSetup.tsx
+++ b/example/src/pages/databases/DatabaseSetup.tsx
@@ -71,7 +71,7 @@ const DatabaseSetupPage: React.FC = () => {
       navigationTitle="Database Setup"
       collapseTitle="Define Database"
       titleButtons={<IonButton
-          key="button-action"
+          key="button-action-path"
           onClick={platformPath}
           style={{
             display: 'block',
@@ -89,15 +89,17 @@ const DatabaseSetupPage: React.FC = () => {
       setDatabaseName={setDatabaseName}
       results={resultsMessage}
     >
-      <IonItem key={1}>
-        <IonInput
+      <IonItem key="item-file-location">
+        <IonInput 
+          key="item-input-file-location"
           placeholder='File Location'
           onInput={(e: any) => setPath(e.target.value)}
           value={path}
         ></IonInput>
       </IonItem>
-      <IonItem key={2}>
+      <IonItem key="item-encryption-key">
         <IonInput
+          key="item-input-encryption-key"
           onInput={(e: any) => setEncryptionKey(e.target.value)}
           placeholder='Encryption Key'
           value={encryptionKey}

--- a/example/src/pages/documents/EditDocument.tsx
+++ b/example/src/pages/documents/EditDocument.tsx
@@ -74,7 +74,12 @@ const EditDocumentPage: React.FC = () => {
                                 const abBlob = DataGeneratorService.getBlobFromBase64(selectedData.blob);
                                 if (abBlob != null) {
                                     const blob = new Blob("image/jpeg", abBlob);
+                                    const encoder = new TextEncoder();
                                     doc.setBlob('image', blob);
+
+                                    //add text blob to the image also
+                                    const textBlob = new Blob("text/plain", encoder.encode("Hello World"));
+                                    doc.setBlob('textBlob', textBlob);
                                 }
                             }
                         }
@@ -110,29 +115,31 @@ const EditDocumentPage: React.FC = () => {
                 setCollectionName={setCollectionName}
                 sectionTitle="Document Information"
                 titleButtons={undefined}>
-                <IonItem key={1}>
+                <IonItem key="item-document-id">
                     <IonInput
+                        key="input-document-id"
                         onInput={(e: any) => setDocumentId(e.target.value)}
                         placeholder="Document ID"
                         value={documentId}
                     ></IonInput>
                 </IonItem>
-                <IonItem key={2} lines="full">
-                    <IonLabel position="stacked">Document</IonLabel>
-                    <textarea
+                <IonItem key="item-document-textarea" lines="full">
+                    <IonLabel key="item-document-label" position="stacked">Document</IonLabel>
+                    <textarea 
+                        key="item-document-textarea-input"
                         style={{width: '100%', padding: '16px 0px'}}
                         rows={4}
                         value={document}
                         onChange={(e: any) => setDocument(e.detail.value)}
                         placeholder="{ 'message': 'hello world' }">
-          </textarea>
+                    </textarea>
                 </IonItem>
-                <IonItemDivider>
-                    <IonLabel>Generated Data</IonLabel>
+                <IonItemDivider key="item-divider-before-generated-data">
+                    <IonLabel key="item-label-generated-data">Generated Data</IonLabel>
                 </IonItemDivider>
-                <IonItem key={3}>
+                <IonItem key="item-generated-documents-select-list">
                     <IonSelect
-                        key={selectKey}
+                        key="selected-document-select-generated-docs"
                         placeholder='Generated Documents'
                         value={selectedDocument}
                         onIonChange={e => {
@@ -145,7 +152,9 @@ const EditDocumentPage: React.FC = () => {
                         }
                         }>
                         {Object.entries(dictionary).map(([key, value]) => (
-                            <IonSelectOption value={key}>{value}</IonSelectOption>
+                            <IonSelectOption 
+                            key={`select-option-key-${key}`}
+                            value={key}>{value}</IonSelectOption>
                         ))}
                     </IonSelect>
                 </IonItem>

--- a/example/src/pages/documents/GetDocument.tsx
+++ b/example/src/pages/documents/GetDocument.tsx
@@ -31,6 +31,15 @@ const GetDocumentPage: React.FC = () => {
           const doc = await collection.document(documentId);
           if (doc !== null && doc.getId() != null) {
             setResultsMessage(prev => [...prev, `${new Date()} Document Found: ` + JSON.stringify(doc)]);
+            if (doc['textBlob'] !== null){
+               const blobText = await doc.getBlobContent('textBlob', collection);
+               if (blobText !== null) {
+                  const textDecoder = new TextDecoder();
+                  const textBlobResults = textDecoder.decode(blobText);
+                  setResultsMessage(prev => [...prev, textBlobResults]);
+
+               }
+            }
           } else {
             setResultsMessage(prev => [...prev, `${new Date()} Error: Document not found`]);
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cbl-ionic",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cbl-ionic",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbl-ionic",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Ionic Capacitor plugin for Couchbase Lite Enterprise (3.x+)",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -80,5 +80,6 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6"
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/src/couchbase-lite/capacitor-engine.ts
+++ b/src/couchbase-lite/capacitor-engine.ts
@@ -127,11 +127,11 @@ export class CapacitorEngine implements IonicCouchbaseLitePlugin {
     return IonicCouchbaseLite.collection_GetDocument(args);
   }
 
-  async collection_GetDocumentBlobContent(
+  async collection_GetBlobContent(
       args: CollectionDocumentGetBlobContentArgs
-  ) : Promise<ArrayBuffer> {
-    const data = await IonicCouchbaseLite.collection_GetDocumentBlobContent(args);
-    return new Uint8Array(data).buffer;
+  ) : Promise<{data: ArrayBuffer}> {
+    const data = await IonicCouchbaseLite.collection_GetBlobContent(args);
+    return {data: new Uint8Array(data.data).buffer};
   }
 
   async collection_GetIndexes(
@@ -323,7 +323,7 @@ export class CapacitorEngine implements IonicCouchbaseLitePlugin {
    */
   async document_GetBlobContent(
       args: DocumentGetBlobContentArgs
-  ): Promise<ArrayBuffer> {
+  ): Promise<{data: ArrayBuffer}> {
     const colArgs:CollectionDocumentGetBlobContentArgs = {
       name: args.name,
       collectionName: this._defaultCollectionName,
@@ -331,8 +331,8 @@ export class CapacitorEngine implements IonicCouchbaseLitePlugin {
       documentId: args.documentId,
       key: args.key
     };
-    const data = await IonicCouchbaseLite.collection_GetDocumentBlobContent(colArgs);
-    return new Uint8Array(data).buffer;
+    const data = await IonicCouchbaseLite.collection_GetBlobContent(colArgs);
+    return {data: new Uint8Array(data.data).buffer};
   }
 
   async file_GetDefaultPath(): Promise<{ path: string }> {


### PR DESCRIPTION
Fixed several issues:

- Fixed issue with blob data in Android where the data wasn't being returned in a JSONArray
- Fixed an issue with the document mapper in the plugin helper that wasn't properly getting blob properties and thus would cause the app to crash.  Also updated the catch to rethrow the error message vs just returning null which isn't helpful when debugging.
- Updated Database Setup page  in example app to fix React duplicate keys errors
- Updated Edit Document page  in example app to fix React duplicate keys errors
- Updated Get Document page  in example app to fix React duplicate keys errors
- Updated Ionic engine code to properly return an Data property with an Uint8Array when returning blob content
- Updated cblite-js version to 0.1.9 which has to fix to the blob array with data element fix.  Updated head pointer to this release.
- Update package.json to version 0.1.9