### PR TITLE
updated to fix issue with replicator document Ids not returning with …

### DIFF
--- a/android/src/main/java/com/couchbase/ionic/CblIonicPluginPlugin.kt
+++ b/android/src/main/java/com/couchbase/ionic/CblIonicPluginPlugin.kt
@@ -1636,7 +1636,7 @@ class CblIonicPluginPlugin : Plugin() {
                     )
                     if (pendingDocIds.isNotEmpty()) {
                         val results = JSObject()
-                        results.put("documentIDs", pendingDocIds)
+                        results.put("pendingDocumentIds", pendingDocIds)
                         call.resolve(results)
                     } else {
                         call.resolve()

--- a/ios/Plugin/CblIonicPlugin.swift
+++ b/ios/Plugin/CblIonicPlugin.swift
@@ -1162,7 +1162,7 @@ public class CblIonicPluginPlugin: CAPPlugin {
                         .shared
                         .getPendingDocumentIds(replicatorId, collection: collection)
                     DispatchQueue.main.async {
-                        call.resolve(documentIds)
+                        call.resolve(["pendingDocumentIds": documentIds])
                         return
                     }
                 } else {

--- a/ios/Plugin/CblIonicPlugin.swift
+++ b/ios/Plugin/CblIonicPlugin.swift
@@ -1162,7 +1162,7 @@ public class CblIonicPluginPlugin: CAPPlugin {
                         .shared
                         .getPendingDocumentIds(replicatorId, collection: collection)
                     DispatchQueue.main.async {
-                        call.resolve(["pendingDocumentIds": documentIds])
+                        call.resolve(documentIds)
                         return
                     }
                 } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cbl-ionic",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cbl-ionic",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbl-ionic",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Ionic Capacitor plugin for Couchbase Lite Enterprise (3.x+)",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Updated issue where pending document ids wasn't returning with the proper name.  In Javascript, we state the property name should be "pendingDocumentIds" in capacitor-engine.ts.  In Swift we were just returning the Set of string back raw and in Anroid we were returning the wrong name - "documentIds".  This updates both Swift and Android to use the proper field name "pendingDocumentIds" to match the interface contract in ICoreEngine's contract definition of:  

```javascript
    replicator_GetPendingDocumentIds(args: ReplicatorCollectionArgs): Promise<{ pendingDocumentIds: string[] }>;
```