### PR TITLE
chore: update Couchbase Lite to version 3.2.2

### DIFF
--- a/CblIonic.podspec
+++ b/CblIonic.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'CouchbaseLite-Swift-Enterprise', '3.2.1'
+  s.dependency 'CouchbaseLite-Swift-Enterprise', '3.2.2'
   s.swift_version = '5.5'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,7 +60,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation "com.couchbase.lite:couchbase-lite-android-ee-ktx:3.2.1"
+    implementation "com.couchbase.lite:couchbase-lite-android-ee-ktx:3.2.2"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'androidx.core:core-ktx:1.10.1'
     testImplementation "junit:junit:$junitVersion"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,7 @@ end
 
 def couchbase_pods
   use_frameworks!
-  pod 'CouchbaseLite-Swift-Enterprise', '3.2.1'
+  pod 'CouchbaseLite-Swift-Enterprise', '3.2.2'
 end
 
 target 'Plugin' do

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbl-ionic",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Ionic Capacitor plugin for Couchbase Lite Enterprise (3.2+)",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/couchbase-lite/capacitor-engine.ts
+++ b/src/couchbase-lite/capacitor-engine.ts
@@ -54,6 +54,7 @@ import { v4 as uuidv4 } from 'uuid';
 export class CapacitorEngine implements IonicCouchbaseLitePlugin {
   _defaultCollectionName = '_default';
   _defaultScopeName = '_default';
+  debugConsole: boolean;
 
   constructor() {
     EngineLocator.registerEngine(EngineLocator.key, this);


### PR DESCRIPTION
This PR updates the Couchbase Lite dependency to version 3.2.2 for both iOS and Android platforms. The following changes were made:

Updated CouchbaseLite-Swift-Enterprise to 3.2.2 in CblIonic.podspec for iOS.
Updated couchbase-lite-android-ee-ktx to 3.2.2 in build.gradle for Android.
Added ```debugConsole``` to ```capacitor-engine.js``` - without this the app was not building, because of TS errors.

I tested the plugin with both Couchbase Lite 3.2.1 and 3.2.2 versions on iOS and Android. The following observations were made:

Crashes:

Some crashes were observed during testing, but these crashes are present in both 3.2.1 and 3.2.2, indicating they are not introduced by this update.

```Collection API/Listen to changes``` providing wrong scope/collection names results in a crash in react rendering layer.

```Document API/Get``` clicking the clock symbol results in a crash in react rendering layer.

Failing Tests:

Some tests are failing, but the failures are consistent across both versions (3.2.1 and 3.2.2).
No new test failures were introduced by this update.

```testReplicatorStatusChangeListenerEvent``` - ```AssertionError: expected +0 to be above +0```
```testDocumentChangeListenerEvent``` - ```Error: AssertionError: expected +0 to be above +0```
```testQueryDateParameter``` - ```{}```

Unimplemented Tests:

Some tests are not implemented, and this behavior is also consistent across both versions.

If specific tests are required to validate this update, please provide guidance on what additional tests are needed. I am happy to assist with further testing or debugging if necessary.