### PR TITLE
Update example app query screens

### DIFF
--- a/example/src/pages/query/LiveQuery.tsx
+++ b/example/src/pages/query/LiveQuery.tsx
@@ -1,112 +1,150 @@
 // LiveQuery.tsx
+import './LiveQuery.css';
 import React, { useState, useContext } from 'react';
 import DatabaseContext from '../../providers/DatabaseContext';
 import DetailPageDatabaseCollectionRun from '../../components/DetailPageDatabaseCollectionRun/DetailPageDatabaseCollectionRun';
-import { MutableDocument, Query} from 'cbl-ionic';
+import { MutableDocument, Query } from 'cbl-ionic';
+import { IonItemDivider, IonLabel, IonButton } from '@ionic/react';
 
 const LiveQueryPage: React.FC = () => {
+    const { databases } = useContext(DatabaseContext)!;
+    const [databaseName, setDatabaseName] = useState<string>('');
+    const [scopeName, setScopeName] = useState<string>('');
+    const [collectionName, setCollectionName] = useState<string>('');
+    const [resultsMessage, setResultsMessage] = useState<string[]>([]);
+    const [query, setQuery] = useState<Query>(null);
+    const [isListenerAdded, setIsListenerAdded] = useState(false);
+    const [token, setToken] = useState<string>('');
 
-  const { databases } = useContext(DatabaseContext)!;
-  const [databaseName, setDatabaseName] = useState<string>('');
-  const [resultsMessage, setResultsMessage] = useState<string[]>([]);
-  const [query, setQuery] = useState<Query>(null);
-  const [scopeName, setScopeName] = useState<string>('');
-  const [collectionName, setCollectionName] = useState<string>('');
-  const [isListenerAdded, setIsListenerAdded] = useState(false);
-  const [token, setToken] = useState<string>('');
+    async function addListener() {
+        let collection = null;
+        if (!(databaseName in databases)) {
+            setResultsMessage(["Error: Database is not set up"]);
+            return;
+        }
 
-  async function update() {
-      if (databaseName in databases) {
-          const database = databases[databaseName];
-          const collection = await database.collection(collectionName, scopeName);
-          if (collection != null){
-              try {
-                  if(!isListenerAdded || token ==='') {
-                      const queryString = `SELECT *
-                                           FROM ${scopeName}.${collectionName} AS testCollection`;
-                      const query = database.createQuery(queryString);
-                      const token = await query.addChangeListener((change) => {
-                          if (change.error !== null && change.error !== undefined) {
-                              setResultsMessage([`${new Date().toISOString()} Error in Change Listener: ${change.error}`]);
-                          } else {
-                              if (change.results.length > 0) {
-                                  const results = change.results;
-                                  for (const doc of results) {
-                                      const obj = doc['testCollection'];
-                                      setResultsMessage(prev => [...prev, `${new Date().toISOString()} : ${obj.counter}`]);
-                                  }
-                              } else {
-                                  setResultsMessage([`${new Date().toISOString()} Results have no data)`]);
-                              }
-                          }
-                      });
-                      setIsListenerAdded(true);
-                      setQuery(query);
-                      setToken(token);
-                      //change documents
-                      const saveDocuments = async (start: number, end: number) => {
-                          for (let count = start; count <= end; count++) {
-                              const doc = new MutableDocument(`doc-${count}`);
-                              doc.setString('counter', count.toString());
-                              await collection.save(doc);
-                          }
-                      }
-                      await saveDocuments(1, 10);
-                      await sleep(5000);
-                      await saveDocuments(11, 20);
-                  }
-              } catch(e) {
-                  setResultsMessage([`${new Date().toISOString()} Error: ${e}`]);
-              }
-          }  else {
-              setResultsMessage([`${new Date().toISOString()} Error: Database or collection is null)`]);
-          }
-      } else {
-          setResultsMessage([`${new Date().toISOString()} Error: Database is not setup (defined)`]);
-      }
+        const database = databases[databaseName];
+        if (!collectionName || !scopeName) {
+            setResultsMessage(["Error: Collection or scope name is empty"]);
+            return;
+        }
 
-  }
+        try {
+            collection = await database.collection(collectionName, scopeName);
+        } catch (error) {
+            setResultsMessage([`Error getting collection: ${error.message}`]);
+            return;
+        }
 
-  async function reset() {
-    const database = databases[databaseName];
+        if (!collection) {
+            setResultsMessage(["Error: Database or collection is null"]);
+            return;
+        }
 
-      if (database != null && isListenerAdded) {
-        await query.removeChangeListener(token);
-        setIsListenerAdded(false);
-        setResultsMessage([
-            `Removed Listening for query changes`,
-        ]);
+        if (isListenerAdded && token !== '') {
+            setResultsMessage(["Listener already added."]);
+            return;
+        }
+
+        try {
+            const queryString = `SELECT * FROM ${scopeName}.${collectionName} WHERE type = 'live-query-example'`;
+            const query = database.createQuery(queryString);
+
+            const listenerToken = await query.addChangeListener((change) => {
+                if (change.error) {
+                    setResultsMessage([`Error in Change Listener: ${change.error}`]);
+                    return;
+                }
+
+                if (change.results.length > 0) {
+                    const results = change.results.map((doc) => JSON.stringify(doc));
+                    setResultsMessage((prev) => [...prev, ...results]);
+                } else {
+                    setResultsMessage(["No data in results"]);
+                }
+
+            });
+
+            setIsListenerAdded(true);
+            setQuery(query);
+            setToken(listenerToken);
+            setResultsMessage(["Listener added successfully."]);
+        } catch (error) {
+            setResultsMessage([`Error adding listener: ${error.message}`]);
+            return;
+        }
     }
-    setCollectionName('');
-    setScopeName('');
-    setDatabaseName('');
-    setResultsMessage([]);
-    setToken('');
-    setQuery(null);
-  }
 
-  function sleep(ms) {
-      return new Promise(resolve => setTimeout(resolve, ms));
-  }
+    async function addDocument() {
+        setResultsMessage([])
+        if (!(databaseName in databases)) {
+            setResultsMessage(["Error: Database is not set up"]);
+            return;
+        }
 
-  return (
-      <DetailPageDatabaseCollectionRun
-          navigationTitle="Query SQL++"
-          collapseTitle="Query SQL++"
-          onReset={reset}
-          onAction={update}
-          results={resultsMessage}
-          databaseName={databaseName}
-          setDatabaseName={setDatabaseName}
-          sectionTitle="Query"
-          collectionName={collectionName}
-          setCollectionName={setCollectionName}
-          scopeName={scopeName}
-          setScopeName={setScopeName}
-          titleButtons={ undefined }>
-      <></>
-      </DetailPageDatabaseCollectionRun>
-  );
+        const database = databases[databaseName];
+        const collection = await database.collection(collectionName, scopeName);
+
+        if (!collection) {
+            setResultsMessage(["Error: Database or collection is null"]);
+            return;
+        }
+
+        const id = Math.floor(Math.random() * 1000).toString();
+        const doc = new MutableDocument(`doc-${id}`);
+        doc.setString('counter', id);
+        doc.setString('type', 'live-query-example');
+        await collection.save(doc);
+        setResultsMessage((prev) => [...prev, `Document ${doc.getId()} added.`]);
+    }
+
+    async function reset() {
+        if (query && isListenerAdded) {
+            await query.removeChangeListener(token);
+            setIsListenerAdded(false);
+            setResultsMessage(["Listener removed successfully."]);
+        }
+
+        setCollectionName('');
+        setScopeName('');
+        setDatabaseName('');
+        setResultsMessage([]);
+        setToken('');
+        setQuery(null);
+    }
+
+    return (
+        <DetailPageDatabaseCollectionRun
+            navigationTitle="Live Query"
+            collapseTitle="Live Query"
+            onAction={addListener}
+            onReset={reset}
+            results={resultsMessage}
+            databaseName={databaseName}
+            setDatabaseName={setDatabaseName}
+            sectionTitle={`Live Query - ${isListenerAdded ? "Listener Added" : "Step 1: Add Listener"}`}
+            collectionName={collectionName}
+            setCollectionName={setCollectionName}
+            scopeName={scopeName}
+            setScopeName={setScopeName}
+            titleButtons={undefined}
+        >
+            <IonItemDivider>
+                <IonLabel>Step 2: Add Document</IonLabel>
+            </IonItemDivider>
+            <IonButton
+                onClick={addDocument}
+                style={{
+                    display: 'block',
+                    marginLeft: 'auto',
+                    marginRight: 'auto',
+                    padding: '10px 20px',
+                }}
+            >
+                Add Document
+            </IonButton>
+        </DetailPageDatabaseCollectionRun>
+    );
 };
 
 export default LiveQueryPage;

--- a/example/src/pages/query/QueryFTS.tsx
+++ b/example/src/pages/query/QueryFTS.tsx
@@ -1,69 +1,126 @@
 // QueryFTS.tsx
 import './LiveQuery.css';
-import React, {useState, useContext} from 'react';
+import React, { useState, useContext, useEffect, useRef } from 'react';
 import DatabaseContext from '../../providers/DatabaseContext';
-import DetailPageContainerItemResults
-    from '../../components/DetailPageContainerItemResults/DetailPageContainerItemResults';
+import DetailPageContainerItemResults from '../../components/DetailPageContainerItemResults/DetailPageContainerItemResults';
 import DatabaseNameForm from '../../components/DatabaseNameForm/DatabaseNameForm';
 
 import {
     IonItemDivider,
     IonLabel,
     IonButton,
-    IonButtons,
     IonInput,
-    IonIcon,
     IonItem,
+    IonCheckbox,
 } from '@ionic/react';
 
-import {playOutline} from 'ionicons/icons';
+import Editor from '@monaco-editor/react';
+import { FullTextIndexItem, IndexBuilder } from 'cbl-ionic';
 
 const QueryFTSPage: React.FC = () => {
-    const {databases} = useContext(DatabaseContext)!;
+    const { databases } = useContext(DatabaseContext)!;
     const [databaseName, setDatabaseName] = useState<string>('');
-    const [indexName, setIndexName] = useState<string>('');
-    const [propertyValue, setPropertyValue] = useState<string>('');
+    const [selectedExample, setSelectedExample] = useState<any>(null);
+    const [indexCreated, setIndexCreated] = useState<boolean>(false);
     const [resultsMessage, setResultsMessage] = useState<string[]>([]);
+    const [indexName, setIndexName] = useState<string>('');
+    const [indexField, setIndexField] = useState<string>('');
+    const [ignoreAccents, setIgnoreAccents] = useState<boolean>(false);
+    const editorRef = useRef(null);
 
-    async function update() {
-        if (databaseName in databases) {
+    const exampleQueries = [
+        {
+            label: "Search for 'Smartphone' in product names",
+            indexName: "productNameIndex",
+            propertyValue: "Smartphone",
+            fields: ["name"],
+        },
+        {
+            label: "Search for 'Electronics' in categories",
+            indexName: "categoryIndex",
+            propertyValue: "Electronics",
+            fields: ["category"],
+        },
+        {
+            label: "Search for 'Warehouse 1' in locations",
+            indexName: "locationIndex",
+            propertyValue: "Warehouse 1",
+            fields: ["location"],
+        },
+    ];
+
+    useEffect(() => {
+        if (databaseName) {
+            setIndexCreated(false);
+        }
+    }, [databaseName]);
+
+    function handleExampleSelection(exampleLabel: string) {
+        const selected = exampleQueries.find((query) => query.label === exampleLabel);
+        if (selected) {
+            setSelectedExample(selected);
+            setIndexName(selected.indexName);
+            setIndexField(selected.fields[0]);
+            setIgnoreAccents(false);
+
+            const fullQuery = `SELECT * FROM _default WHERE MATCH(${selected.indexName}, '${selected.propertyValue}')`;
+            if (editorRef.current) {
+                editorRef.current.setValue(fullQuery);
+            }
+
+            setIndexCreated(false);
+            setResultsMessage([]);
+        }
+    }
+
+    async function createFTSIndex() {
+        if (databaseName in databases && indexName && indexField) {
             const database = databases[databaseName];
-            if (database != null) {
-                if (indexName.length > 0 && propertyValue.length > 0) {
-                    //create query
-                    const whereClause = "MATCH(" + indexName + ", '" + propertyValue + "')";
-                    const ftsQueryString = "SELECT * FROM " + whereClause;
-                    const ftsQuery = database.createQuery(ftsQueryString);
-                    try {
-                        const results = await ftsQuery.execute();
-                        const resultsArray: string[] = []
-                        for (const key in results) {
-                            resultsArray.push(JSON.stringify(results[key]));
-                        }
-                        setResultsMessage(resultsArray);
-                    } catch (error) {
-                        setResultsMessage([
-                            `Error: ${error}`,
-                        ]);
-                    }
-                } else {
-                    setResultsMessage(prev => [...prev,
-                        `${new Date().toISOString()} Error: Property Name or Property Value not defined`,
-                    ]);
-                }
-            } else {
-                setResultsMessage(prev => [...prev, `${new Date().toISOString()} Error: Index name or field is not defined`]);
+            try {
+                const indexProperty = FullTextIndexItem.property(indexField);
+
+                const index = IndexBuilder.fullTextIndex(indexProperty).setIgnoreAccents(ignoreAccents);
+
+                await database.createIndex(indexName, index);
+
+                setIndexCreated(true);
+                setResultsMessage([`FTS Index '${indexName}' created successfully.`]);
+            } catch (error) {
+                setResultsMessage([`Error creating FTS Index: ${error}`]);
             }
         } else {
-            setResultsMessage( prev => [...prev, `${new Date().toISOString()} Error: Database is not setup (defined)`]);
+            setResultsMessage(["Error: Database, index name, or field is not defined."]);
+        }
+    }
+
+    async function runQuery() {
+        if (databaseName in databases && editorRef.current) {
+            const database = databases[databaseName];
+            try {
+                const queryString = editorRef.current.getValue();
+                const query = database.createQuery(queryString);
+                const results = await query.execute();
+                const resultsArray: string[] = [];
+                for (const key in results) {
+                    resultsArray.push(JSON.stringify(results[key]));
+                }
+                setResultsMessage(resultsArray);
+            } catch (error) {
+                setResultsMessage([`Error running query: ${error}`]);
+            }
+        } else {
+            setResultsMessage(["Error: Database or query is not defined."]);
         }
     }
 
     function reset() {
         setDatabaseName('');
-        setIndexName('');
-        setPropertyValue('');
+        setSelectedExample(null);
+        setIndexCreated(false);
         setResultsMessage([]);
+        setIndexName('');
+        setIndexField('');
+        setIgnoreAccents(false);
     }
 
     return (
@@ -71,7 +128,7 @@ const QueryFTSPage: React.FC = () => {
             navigationTitle="Query Builder FTS"
             collapseTitle="Query Builder FTS"
             onReset={reset}
-            resultsCount="0"
+            resultsCount={resultsMessage.length.toString()}
             children={
                 <>
                     <DatabaseNameForm
@@ -79,36 +136,101 @@ const QueryFTSPage: React.FC = () => {
                         databaseName={databaseName}
                     />
                     <IonItemDivider>
-                        <IonLabel>Query Builder</IonLabel>
-                        <IonButtons slot="end">
+                        <IonLabel>Example Queries</IonLabel>
+                    </IonItemDivider>
+                    <div style={{ padding: "10px" }}>
+                        <select
+                            defaultValue=""
+                            onChange={(e) => handleExampleSelection(e.target.value)}
+                            style={{
+                                width: "100%",
+                                padding: "10px",
+                                fontSize: "14px",
+                            }}
+                        >
+                            <option value="" disabled>
+                                Select an example query
+                            </option>
+                            {exampleQueries.map((example, index) => (
+                                <option key={index} value={example.label}>
+                                    {example.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <IonItemDivider>
+                        <IonLabel>Custom Index Builder</IonLabel>
+                    </IonItemDivider>
+                    <IonItem>
+                        <IonInput
+                            onInput={(e: any) => setIndexName(e.target.value)}
+                            placeholder="Index Name"
+                            value={indexName}
+                        ></IonInput>
+                    </IonItem>
+                    <IonItem>
+                        <IonInput
+                            onInput={(e: any) => setIndexField(e.target.value)}
+                            placeholder="Index Field"
+                            value={indexField}
+                        ></IonInput>
+                    </IonItem>
+                    <IonItem>
+                        <IonLabel>Ignore Accents</IonLabel>
+                        <IonCheckbox
+                            checked={ignoreAccents}
+                            onIonChange={(e: any) => setIgnoreAccents(e.detail.checked)}
+                        ></IonCheckbox>
+                    </IonItem>
+                    <IonButton
+                        onClick={createFTSIndex}
+                        disabled={indexCreated}
+                        style={{
+                            display: 'block',
+                            marginLeft: 'auto',
+                            marginRight: 'auto',
+                            padding: '10px 20px',
+                        }}
+                    >
+                        {indexCreated ? "Index Created" : "Create Index"}
+                    </IonButton>
+
+                    <IonItemDivider>
+                        <IonLabel>Custom Query Editor</IonLabel>
+                    </IonItemDivider>
+                    <div className="pt-2 pb-2">
+                        <Editor
+                            onMount={(editor) => (editorRef.current = editor)}
+                            height="15vh"
+                            defaultLanguage="sql"
+                            defaultValue="SELECT * FROM _default"
+                            theme="vs-dark"
+                            options={{
+                                wordWrap: "on",
+                                wrappingIndent: "same",
+                            }}
+                        />
+                    </div>
+
+                    {selectedExample && (
+                        <>
+                            <IonItemDivider>
+                                <IonLabel>Step 2: Run Query</IonLabel>
+                            </IonItemDivider>
                             <IonButton
-                                onClick={update}
+                                onClick={runQuery}
                                 style={{
                                     display: 'block',
                                     marginLeft: 'auto',
                                     marginRight: 'auto',
-                                    padding: '0px 5px',
+                                    padding: '10px 20px',
                                 }}
                             >
-                                <IonIcon icon={playOutline}/>
+                                Run Query
                             </IonButton>
-                        </IonButtons>
-                    </IonItemDivider>
-
-                    <IonItem key={2}>
-                        <IonInput
-                            onInput={(e: any) => setIndexName(e.target.value)}
-                            placeholder="FTS Index Name"
-                            value={indexName}
-                        ></IonInput>
-                    </IonItem>
-                    <IonItem key={3}>
-                        <IonInput
-                            onInput={(e: any) => setPropertyValue(e.target.value)}
-                            placeholder="Value to Search"
-                            value={propertyValue}
-                        ></IonInput>
-                    </IonItem>
+                        </>
+                    )}
                 </>
             }
             resultsChildren={
@@ -123,4 +245,5 @@ const QueryFTSPage: React.FC = () => {
         ></DetailPageContainerItemResults>
     );
 };
+
 export default QueryFTSPage;

--- a/example/src/pages/query/SqlPlusPlus.tsx
+++ b/example/src/pages/query/SqlPlusPlus.tsx
@@ -1,65 +1,171 @@
 // SqlPlusPlus.tsx
-import React, {useState, useContext, useRef} from 'react';
-import DatabaseContext from '../../providers/DatabaseContext';
-import DetailPageContainerRun from '../../components/DetailPageContainerRun/DetailPageContainerRun';
+import React, { useState, useContext, useRef, useEffect } from "react";
+import DatabaseContext from "../../providers/DatabaseContext";
+import DetailPageContainerRun from "../../components/DetailPageContainerRun/DetailPageContainerRun";
 
-import Editor from '@monaco-editor/react';
-import {
-    IonButton,
-    IonButtons,
-    IonItemDivider,
-    IonLabel,
-    IonCard,
-} from "@ionic/react";
+import Editor from "@monaco-editor/react";
+import { IonItemDivider, IonLabel } from "@ionic/react";
+import { Link } from "react-router-dom";
+
+const exampleQueries = [
+    {
+        label: "Get all products",
+        query: `SELECT * FROM _default WHERE documentType = "product"`,
+    },
+    {
+        label: "Products on sale",
+        query: `SELECT name, price 
+FROM _default 
+WHERE documentType = "product" 
+  AND isOnSale = true`,
+    },
+    {
+        label: "Products grouped by category",
+        query: `SELECT category, COUNT(*) AS productCount 
+FROM _default 
+WHERE documentType = "product" 
+GROUP BY category`,
+    },
+    {
+        label: "Products with quantity > 50",
+        query: `SELECT name, quantity 
+FROM _default 
+WHERE documentType = "product" 
+  AND quantity > 50`,
+    },
+    {
+        label: "Products with price > 500",
+        query: `SELECT name, price 
+FROM _default 
+WHERE documentType = "product" 
+  AND price > 500`,
+    },
+    {
+        label: "Products grouped by location",
+        query: `SELECT location, COUNT(*) AS productCount 
+FROM _default 
+WHERE documentType = "product" 
+GROUP BY location`,
+    },
+    {
+        label: "Products grouped by category with count > 2",
+        query: `SELECT category, COUNT(*) AS productCount 
+FROM _default 
+WHERE documentType = "product" 
+GROUP BY category 
+HAVING COUNT(*) > 2`,
+    },
+    {
+        label: "Top 5 most expensive products",
+        query: `SELECT name, price 
+FROM _default 
+WHERE documentType = "product" 
+ORDER BY price DESC 
+LIMIT 5`,
+    },
+    {
+        label: "Products created after 2024-01-01",
+        query: `SELECT name, createdOn 
+FROM _default 
+WHERE documentType = "product" 
+  AND createdOn > "2024-01-01T00:00:00.000Z"`,
+    },
+    {
+        label: "Products sorted by quantity (descending)",
+        query: `SELECT name, quantity 
+FROM _default 
+WHERE documentType = "product" 
+ORDER BY quantity DESC`,
+    },
+];
 
 const SqlPlusPlusPage: React.FC = () => {
-
-    const {databases} = useContext(DatabaseContext)!;
-    const [databaseName, setDatabaseName] = useState<string>('');
+    const { databases } = useContext(DatabaseContext)!;
+    const [databaseName, setDatabaseName] = useState<string>("");
     const [resultsMessage, setResultsMessage] = useState<string[]>([]);
-    const [parametersCount, setParametersCount] = useState<number>(0);
+    const [hasDocuments, setHasDocuments] = useState<boolean>(true);
     const editorRef = useRef(null);
-    const parameterTypes: string[] = ['string', 'boolean', 'float', 'double', 'int', 'int64', 'date'];
+
+
+    useEffect(() => {
+        checkDocuments();
+    }, [databaseName]);
+
+    async function checkDocuments() {
+        if (!(databaseName in databases)) {
+            setHasDocuments(false);
+            return;
+        }
+
+        const database = databases[databaseName];
+        if (!database) {
+            setHasDocuments(false);
+            return;
+        }
+
+        try {
+            const query = database.createQuery(`SELECT COUNT(*) AS docCount FROM _default`);
+            const resultSet = await query.execute();
+            if (resultSet[0].docCount > 0) {
+                setHasDocuments(true);
+                return;
+            }
+            setHasDocuments(false);
+
+        } catch (e) {
+            console.error("Error checking documents:", e);
+            setHasDocuments(false);
+        }
+    }
 
     function handleEditorDidMount(editor, monaco) {
         editorRef.current = editor;
     }
 
-    async function update() {
-        setResultsMessage([]);
-        if (databaseName in databases) {
-            const database = databases[databaseName];
-            const queryString = editorRef.current.getValue();
-            if (database != null && queryString != null) {
-                try {
-                    const query = database.createQuery(queryString);
-                    const resultSet = await query.execute();
-                    for (const result of resultSet) {
-                        setResultsMessage(prev => [
-                            ...prev,
-                            `${new Date().toISOString()} Result: ` + JSON.stringify(result),
-                        ]);
-                    }
-                } catch(e){
-                    setResultsMessage([`${new Date().toISOString()} Error: ${e}`]);
-                }
-            }
-            else {
-                setResultsMessage([`${new Date().toISOString()} Error: Database is null)`]);
-            }
-        } else {
-            setResultsMessage([`${new Date().toISOString()} Error: Database is not setup (defined)`]);
+    function setEditorQuery(query: string) {
+        if (editorRef.current) {
+            editorRef.current.setValue(query);
         }
     }
 
-    function addParameter() {
-        setParametersCount(prev => prev + 1);
+    async function update() {
+        setResultsMessage([]);
+
+        if (!(databaseName in databases)) {
+            setResultsMessage([`${new Date().toISOString()} Error: Database is not setup (defined)`]);
+            return;
+        }
+
+        const database = databases[databaseName];
+        if (!database) {
+            setResultsMessage([`${new Date().toISOString()} Error: Database is null)`]);
+            return;
+        }
+
+        const queryString = editorRef.current?.getValue();
+        if (!queryString) {
+            setResultsMessage([`${new Date().toISOString()} Error: Query string is empty or invalid`]);
+            return;
+        }
+
+        try {
+            const query = database.createQuery(queryString);
+            const resultSet = await query.execute();
+
+            for (const result of resultSet) {
+                setResultsMessage((prev) => [
+                    ...prev,
+                    `${new Date().toISOString()} Result: ` + JSON.stringify(result),
+                ]);
+            }
+        } catch (e) {
+            setResultsMessage([`${new Date().toISOString()} Error: ${e}`]);
+        }
     }
 
     function reset() {
-      setDatabaseName('');
-      setResultsMessage([]);
-      setParametersCount(0);
+        setDatabaseName("");
+        setResultsMessage([]);
     }
 
     return (
@@ -72,39 +178,68 @@ const SqlPlusPlusPage: React.FC = () => {
             databaseName={databaseName}
             setDatabaseName={setDatabaseName}
             sectionTitle="Query"
-            titleButtons={ undefined }>
+            titleButtons={undefined}
+        >
             <>
-            <div className="pt-2 pb-2">
-            <Editor
-                onMount={handleEditorDidMount}
-                height="15vh"
-                defaultLanguage="sql"
-                defaultValue="SELECT * FROM myCollection"
-                theme="vs-dark"/>
-            </div>
-                <IonItemDivider key="parameter-divider-key">
-                    <IonLabel key="parameters-divider-label-key">Parameters</IonLabel>
-                    <IonButtons slot="end" key="section-divider-buttons-key">
-                        <IonButton
-                            key="document-batch-divider-right-buttons-validate-button-key"
-                            onClick={addParameter}
+                {!hasDocuments && (
+                    <div style={{ padding: "10px", backgroundColor: "#fff3cd", border: "1px solid #ffeeba", borderRadius: "5px", marginBottom: "15px" }}>
+                        <p style={{ margin: 0, color: "#856404" }}>
+                            No documents found in the database. Please create documents using the <strong>Create Batch</strong> functionality.
+                        </p>
+                        <Link
+                            to="/documents/batch/create"
                             style={{
-                                display: 'block',
-                                marginLeft: 'auto',
-                                marginRight: 'auto',
-                                padding: '0px 5px',
+                                display: "inline-block",
+                                marginTop: "10px",
+                                padding: "10px 15px",
+                                backgroundColor: "#007bff",
+                                color: "#fff",
+                                textDecoration: "none",
+                                borderRadius: "5px",
+                                cursor: "pointer",
                             }}
                         >
-                            <i className="fa-solid fa-layer-plus"></i>
-                        </IonButton>
-                    </IonButtons>
+                            Go to Create Batch
+                        </Link>
+                    </div>
+                )}
+                <div className="pt-2 pb-2">
+                    <Editor
+                        onMount={handleEditorDidMount}
+                        height="15vh"
+                        defaultLanguage="sql"
+                        defaultValue="SELECT * FROM _default"
+                        theme="vs-dark"
+                        options={{
+                            wordWrap: "on",
+                            wrappingIndent: "same",
+                        }}
+                    />
+                </div>
+                <IonItemDivider>
+                    <IonLabel>Example Queries</IonLabel>
                 </IonItemDivider>
-                {[...Array(parametersCount)].map((_, index) => (
-                    <IonCard key={index}>
-                    </IonCard>
-
-                ))}
-          </>
+                <div style={{ padding: "10px" }}>
+                    <select
+                        defaultValue=""
+                        onChange={(e) => setEditorQuery(e.target.value)}
+                        style={{
+                            width: "100%",
+                            padding: "10px",
+                            fontSize: "14px",
+                        }}
+                    >
+                        <option value="" disabled>
+                            Select an example query
+                        </option>
+                        {exampleQueries.map((example, index) => (
+                            <option key={index} value={example.query}>
+                                {example.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            </>
         </DetailPageContainerRun>
     );
 };


### PR DESCRIPTION
### This PR updates the Query screens from the example app.

### Sql++ screen:
Until the user provides a db that has some documents, a redirect message to Create Batch will be showing up, to make it easier as it's required for the example screens.
<img width="366" alt="image" src="https://github.com/user-attachments/assets/0f02f973-c9f4-43b3-a291-215f594b7172" />

After that the user can select one of few example queries or write his own and run them.
<img width="363" alt="image" src="https://github.com/user-attachments/assets/60dec5bf-5705-46ab-88ed-75fadf991d98" />

### Query - FTS screen:
Here we also provide few example queries. Selecting one will fill out all the values in creating index form, and also provide the query to run a MATCH. The user then has to click the Create Index button and Run Query to see the results. He can also change any values in the form or in the editor.
<img width="365" alt="image" src="https://github.com/user-attachments/assets/c501487b-c042-4a9d-8ad3-aaef782d2688" />

## Live Query screen:
After the user provides the db, scope & collection names, he needs to add the listener by clicking a button.
Then we provide a Add Document button that will trigger the listener and show the results.
<img width="364" alt="image" src="https://github.com/user-attachments/assets/27d2b388-1c3a-4561-9093-2b571a4f3210" />
<img width="364" alt="image" src="https://github.com/user-attachments/assets/89a39721-c940-4eaf-9a7b-ad7232a96165" />



