### PR TITLE
Added Changes for Scarf Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-typescript": "^11.1.6"
+        "@rollup/plugin-typescript": "^11.1.6",
+        "@scarf/scarf": "^1.4.0"
       },
       "devDependencies": {
         "@capacitor/android": "^6.1.2",
@@ -601,6 +602,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,12 @@
   "dependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@rollup/plugin-typescript": "^11.1.6"
+    "@rollup/plugin-typescript": "^11.1.6",
+    "@scarf/scarf": "^1.4.0"
+  },
+  "scarfSettings": {
+    "defaultOptIn": true,
+    "allowTopLevel": true
   },
   "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }


### PR DESCRIPTION
Adds [Scarf](https://docs.scarf.sh/package-analytics/) package analytics to track npm installation metrics.

Changes:

- Added `@scarf/scarf` dependency to `package.json`
- `scarfSettings` configured with `defaultOptIn: true`
-  `package-lock.json` updated with resolved Scarf dependency

Users can opt out by setting `SCARF_ANALYTICS=false`